### PR TITLE
Seminar6 + 7 과제 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	//lombok
+	compileOnly("org.projectlombok:lombok:1.18.38")
+	annotationProcessor("org.projectlombok:lombok:1.18.38")
+
+	testCompileOnly("org.projectlombok:lombok:1.18.38")
+	testAnnotationProcessor("org.projectlombok:lombok:1.18.38")
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -47,8 +47,19 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+
+	//dsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+
+clean {
+	delete file('src/main/generated')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ dependencies {
 
 	testCompileOnly("org.projectlombok:lombok:1.18.38")
 	testAnnotationProcessor("org.projectlombok:lombok:1.18.38")
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.2.4'
-	id 'io.spring.dependency-management' version '1.1.4'
+	id 'org.springframework.boot' version '3.3.6'
+	id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'org.sopt'
@@ -44,6 +44,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/common/AuthErrorCode.java
+++ b/src/main/java/org/sopt/common/AuthErrorCode.java
@@ -1,0 +1,20 @@
+package org.sopt.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode{
+    USER_NOT_REGISTERED(HttpStatus.BAD_REQUEST, "존재하지 않는 유저입니다."),
+    EXPIRED_TOKEN_ERROR(HttpStatus.UNAUTHORIZED,  "만료된 토큰입니다."),
+    TOKEN_MALFORMED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 올바르지 않습니다."),
+    TOKEN_TYPE_ERROR(HttpStatus.UNAUTHORIZED, "토큰 타입이 일치하지 않거나 비어있습니다."),
+    TOKEN_UNSUPPORTED_ERROR(HttpStatus.UNAUTHORIZED, "지원하지않는 토큰입니다."),
+    TOKEN_UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "알 수 없는 토큰입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "자격 증명이 이루어지지 않았습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/sopt/common/CommentErrorCode.java
+++ b/src/main/java/org/sopt/common/CommentErrorCode.java
@@ -1,0 +1,25 @@
+package org.sopt.common;
+
+import org.springframework.http.HttpStatus;
+
+public enum CommentErrorCode implements ErrorCode{
+
+    TOO_LONG_CONTENT(HttpStatus.BAD_REQUEST, "댓글은 300자 이하이어야 합니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다."),
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    CommentErrorCode(HttpStatus httpStatus, String message) {
+        this.httpStatus = httpStatus;
+        this.message = message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/org/sopt/common/CommentErrorCode.java
+++ b/src/main/java/org/sopt/common/CommentErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum CommentErrorCode implements ErrorCode{
 
     TOO_LONG_CONTENT(HttpStatus.BAD_REQUEST, "댓글은 300자 이하이어야 합니다."),
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다."),
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/org/sopt/common/CommonApiResponse.java
+++ b/src/main/java/org/sopt/common/CommonApiResponse.java
@@ -34,6 +34,10 @@ public class CommonApiResponse<T>{
         return new CommonApiResponse<>(errorCode.getHttpStatus().value(), errorCode.getMessage());
     }
 
+    public static <T> CommonApiResponse<T> onFailure(ErrorCode errorCode, String message){
+        return new CommonApiResponse<>(errorCode.getHttpStatus().value(), message);
+    }
+
     public int getCode() {
         return code;
     }

--- a/src/main/java/org/sopt/common/CommonErrorCode.java
+++ b/src/main/java/org/sopt/common/CommonErrorCode.java
@@ -1,0 +1,22 @@
+package org.sopt.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    // 400
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 자원을 찾을 수 없습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST,  "잘못된 요청 값입니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST,  "필수 요청 파라미터가 누락되었습니다"),
+
+    //500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/sopt/common/PostErrorCode.java
+++ b/src/main/java/org/sopt/common/PostErrorCode.java
@@ -6,7 +6,7 @@ public enum PostErrorCode implements ErrorCode {
 
     TOO_LONG_TITLE(HttpStatus.BAD_REQUEST, "제목은 30자 미만이어야 합니다."),
     TOO_LONG_CONTENT(HttpStatus.BAD_REQUEST, "게시글은 100자 미만이어야 합니다."),
-    EMPTY_POST(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다."),
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 게시글이 존재하지 않습니다."),
     DUPLICATE_TITLE(HttpStatus.BAD_REQUEST, "같은 제목의 게시글은 작성할 수 없습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/org/sopt/common/TagErrorCode.java
+++ b/src/main/java/org/sopt/common/TagErrorCode.java
@@ -1,0 +1,15 @@
+package org.sopt.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TagErrorCode implements ErrorCode{
+
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 태그가 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/org/sopt/config/QueryDslConfig.java
+++ b/src/main/java/org/sopt/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package org.sopt.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/org/sopt/config/SwaggerConfig.java
+++ b/src/main/java/org/sopt/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package org.sopt.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        // Bearer Token을 위한 SecurityScheme 정의
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        // SecurityRequirement 정의
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("bearerAuth");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("한줄게시판 API")
+                        .description("sopt 과제 API입니다.")
+                        .version("1.0.0"))
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .addSecurityItem(securityRequirement);
+    }
+}

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -1,0 +1,81 @@
+package org.sopt.controller;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.sopt.domain.User;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+//http://soptUser:sopt1234@localhost:8080/login로 요청 보냄 : soptUser:sopt1234가 헤더
+@RestController
+public class AuthController {
+
+    @GetMapping("/login")
+    public ResponseEntity<String> login(HttpServletRequest request){
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Basic")){
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("헤더가 이상합니다.");
+        }
+
+        String decodedString = authHeader.substring("Basic ".length());
+        byte[] decodedByte = Base64.getDecoder().decode(decodedString);
+        String credentials = new String(decodedByte, StandardCharsets.UTF_8);
+
+        String [] parts = credentials.split(":");
+        String userName = parts[0];
+        String password = parts[1];
+
+        if (userName.equals("soptUser") && password.equals("sopt1234")){
+            return ResponseEntity.ok("인증 성공");
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("인증 실패");
+        }
+    }
+
+    @GetMapping("/set-cookie")
+    public ResponseEntity<String> setCookie(HttpServletRequest request, HttpServletResponse response){
+        String userName = "userSopt";
+        String password = "sopt1234";
+
+        Cookie userNameCookie = new Cookie("userId", userName);
+        Cookie passwordCookie = new Cookie("password", password);
+
+        userNameCookie.setPath("/");
+        passwordCookie.setPath("/"); //쿠키 허용 범위 지정
+
+        response.addCookie(userNameCookie); //응답에 쿠키 담기 : 서버에서 내려줄 수도 있고 클라이언트에서 설정해줄수도 있음
+        response.addCookie(passwordCookie);
+
+        return ResponseEntity.ok("쿠키를 잘 구웠습니다.");
+    }
+
+    @GetMapping("/get-cookie")
+    public ResponseEntity<String> getCookie(
+            @CookieValue("userId") String userId, @CookieValue("password") String password){
+        return ResponseEntity.ok("받은 쿠키 " + "유저 아이디 :" + userId + "유저 비밀번호 :"+password);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login2(
+            HttpServletRequest request){
+        String userId = "userSopt";
+        String password = "sopt1234";
+
+        if (userId.equals("userSopt") && password.equals("sopt1234")){
+            HttpSession session = request.getSession(true);
+            session.setAttribute("user", new User("soptUser")); //클라이언트에겐 세션 id에 해당하는 쿠키값을 보냄 -> 세션 스토리지에 세션 저장됨
+            return ResponseEntity.ok("세션 저장 완료");
+        }
+
+        throw  new RuntimeException("");
+    }
+}

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -4,22 +4,39 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.CommonApiResponse;
+import org.sopt.common.CommonSuccessCode;
 import org.sopt.domain.User;
+import org.sopt.dto.LoginRequest;
+import org.sopt.dto.LoginResponse;
+import org.sopt.service.AuthService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 //http://soptUser:sopt1234@localhost:8080/login로 요청 보냄 : soptUser:sopt1234가 헤더
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/auth")
 public class AuthController {
 
-    @GetMapping("/login")
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<CommonApiResponse<LoginResponse>> login(
+            @Valid @RequestBody LoginRequest request
+    ){
+        LoginResponse response = authService.login(request);
+        return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
+                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,response));
+    }
+
+    /*@GetMapping("/login")
     public ResponseEntity<String> login(HttpServletRequest request){
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Basic")){
@@ -77,5 +94,5 @@ public class AuthController {
         }
 
         throw  new RuntimeException("");
-    }
+    }*/
 }

--- a/src/main/java/org/sopt/controller/AuthController.java
+++ b/src/main/java/org/sopt/controller/AuthController.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.common.CommonApiResponse;
 import org.sopt.common.CommonSuccessCode;
 import org.sopt.domain.User;
@@ -22,7 +23,8 @@ import java.util.Base64;
 //http://soptUser:sopt1234@localhost:8080/login로 요청 보냄 : soptUser:sopt1234가 헤더
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/auth")
+@RequestMapping("/api/v1/auth")
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
@@ -32,8 +34,8 @@ public class AuthController {
             @Valid @RequestBody LoginRequest request
     ){
         LoginResponse response = authService.login(request);
-        return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
-                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,response));
+        return ResponseEntity.ok(CommonApiResponse.onSuccess(CommonSuccessCode.OK, response));
+
     }
 
     /*@GetMapping("/login")

--- a/src/main/java/org/sopt/controller/CommentController.java
+++ b/src/main/java/org/sopt/controller/CommentController.java
@@ -1,0 +1,31 @@
+package org.sopt.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.CommonApiResponse;
+import org.sopt.common.CommonSuccessCode;
+import org.sopt.dto.CommentIdResponse;
+import org.sopt.dto.CommentRequest;
+import org.sopt.service.CommentService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/comments")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{postId}")
+    public ResponseEntity<CommonApiResponse<CommentIdResponse>> createComment(
+            @Valid @RequestBody CommentRequest request,
+            @PathVariable final Long postId,
+            @RequestHeader final Long userId
+            ){
+        CommentIdResponse response = commentService.createComment(request, userId, postId);
+        return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
+                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,response));
+    }
+
+}

--- a/src/main/java/org/sopt/controller/CommentController.java
+++ b/src/main/java/org/sopt/controller/CommentController.java
@@ -8,6 +8,7 @@ import org.sopt.dto.CommentIdResponse;
 import org.sopt.dto.CommentRequest;
 import org.sopt.service.CommentService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,7 +22,7 @@ public class CommentController {
     public ResponseEntity<CommonApiResponse<CommentIdResponse>> createComment(
             @Valid @RequestBody CommentRequest request,
             @PathVariable final Long postId,
-            @RequestHeader final Long userId
+            @AuthenticationPrincipal Long userId
             ){
         CommentIdResponse response = commentService.createComment(request, userId, postId);
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -1,18 +1,28 @@
 package org.sopt.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.sopt.common.CommonApiResponse;
+import org.sopt.common.CommonSuccessCode;
+import org.sopt.dto.ToggleLikeRequest;
+import org.sopt.service.LikeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/like")
+@RequestMapping("/api/v1/likes")
 public class LikeController {
 
-    @PostMapping("/{commentId}")
-    public ResponseEntity<Void> toggleCommentLike(
-            @PathVariable final Long commentId,
-            @RequestHeader final Long userId) {
+    private final LikeService likeService;
 
+    @PostMapping
+    public ResponseEntity<CommonApiResponse<Void>> toggleLike(
+            @Valid @RequestBody final ToggleLikeRequest request,
+            @RequestHeader final Long userId) {
+        likeService.toggleLike(userId, request);
+
+        return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
+                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK));
     }
 }

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -1,0 +1,18 @@
+package org.sopt.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/like")
+public class LikeController {
+
+    @PostMapping("/{commentId}")
+    public ResponseEntity<Void> toggleCommentLike(
+            @PathVariable final Long commentId,
+            @RequestHeader final Long userId) {
+
+    }
+}

--- a/src/main/java/org/sopt/controller/LikeController.java
+++ b/src/main/java/org/sopt/controller/LikeController.java
@@ -7,6 +7,7 @@ import org.sopt.common.CommonSuccessCode;
 import org.sopt.dto.ToggleLikeRequest;
 import org.sopt.service.LikeService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,7 +20,7 @@ public class LikeController {
     @PostMapping
     public ResponseEntity<CommonApiResponse<Void>> toggleLike(
             @Valid @RequestBody final ToggleLikeRequest request,
-            @RequestHeader final Long userId) {
+            @AuthenticationPrincipal Long userId) {
         likeService.toggleLike(userId, request);
 
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -64,14 +64,14 @@ public class PostController {
                 .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK));    }
 
     @GetMapping(value = "/search", params = "keyword")
-    public ResponseEntity<CommonApiResponse<PostAllResponse>> searchPostsByKeyword(
+    public ResponseEntity<CommonApiResponse<PostSearchResponse>> searchPostsByKeyword(
             @RequestParam final String keyword
     ) {
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
                 .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,postService.searchPostsByKeyword(keyword)));    }
 
     @GetMapping(value = "/search/tag", params = "tag")
-    public ResponseEntity<CommonApiResponse<PostAllResponse>> searchPostsByTag(
+    public ResponseEntity<CommonApiResponse<PostSearchResponse>> searchPostsByTag(
             @RequestParam final String tag
     ) {
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -30,9 +30,12 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<CommonApiResponse<PostAllResponse>> getAllPosts() {
+    public ResponseEntity<CommonApiResponse<PostAllResponse>> getAllPosts(
+            @RequestParam int size,
+            @RequestParam int page
+    ) {
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
-                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,postService.getAllPosts()));
+                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,postService.getAllPosts(size, page)));
     }
 
     @GetMapping("/{contentId}")

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -42,13 +42,15 @@ public class PostController {
     }
 
     @PatchMapping("/{contentId}")
-    public ResponseEntity<CommonApiResponse<PostResponse>> updatePostTitle(
+    public ResponseEntity<CommonApiResponse<Void>> updatePostTitle(
             @PathVariable final Long contentId,
             @RequestBody PostUpdateRequest request,
             @RequestHeader final Long userId) {
         TextUtil.validatePost(request.title(), request.content());
+        postService.updatePost(contentId, request, userId);
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
-                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK,postService.updatePost(contentId, request, userId)));    }
+                .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK));
+    }
 
     @DeleteMapping("/{contentId}")
     public ResponseEntity<CommonApiResponse<Void>> deletePostById(

--- a/src/main/java/org/sopt/controller/PostController.java
+++ b/src/main/java/org/sopt/controller/PostController.java
@@ -7,6 +7,7 @@ import org.sopt.dto.*;
 import org.sopt.service.PostService;
 import org.sopt.utils.TextUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,7 +22,7 @@ public class PostController {
     @PostMapping
     public ResponseEntity<CommonApiResponse<PostIdResponse>> createPost(
             @Valid @RequestBody PostRequest request,
-            @RequestHeader final Long userId) {
+            @AuthenticationPrincipal Long userId) {
         TextUtil.validatePost(request.title(), request.content());
         PostIdResponse response = postService.createPost(request, userId);
         return ResponseEntity.status(CommonSuccessCode.CREATED.getHttpStatus())
@@ -48,7 +49,7 @@ public class PostController {
     public ResponseEntity<CommonApiResponse<Void>> updatePostTitle(
             @PathVariable final Long contentId,
             @RequestBody PostUpdateRequest request,
-            @RequestHeader final Long userId) {
+            @AuthenticationPrincipal Long userId) {
         TextUtil.validatePost(request.title(), request.content());
         postService.updatePost(contentId, request, userId);
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
@@ -58,7 +59,7 @@ public class PostController {
     @DeleteMapping("/{contentId}")
     public ResponseEntity<CommonApiResponse<Void>> deletePostById(
             @PathVariable final Long contentId,
-            @RequestHeader final Long userId) {
+            @AuthenticationPrincipal Long userId) {
         postService.deletePostById(contentId, userId);
         return ResponseEntity.status(CommonSuccessCode.OK.getHttpStatus())
                 .body(CommonApiResponse.onSuccess(CommonSuccessCode.OK));    }

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -1,0 +1,43 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.domain.common.BaseTimeEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @OneToMany(mappedBy = "like", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Like> likes = new ArrayList<>();
+
+    private Comment(String content, User user, Post post) {
+        this.content = content;
+        this.user = user;
+        this.post = post;
+    }
+
+    public static Comment createComment(String content, User user, Post post){
+        return new Comment(content, user, post);
+    }
+}

--- a/src/main/java/org/sopt/domain/Comment.java
+++ b/src/main/java/org/sopt/domain/Comment.java
@@ -28,7 +28,7 @@ public class Comment extends BaseTimeEntity {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    @OneToMany(mappedBy = "like", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Like> likes = new ArrayList<>();
 
     private Comment(String content, User user, Post post) {

--- a/src/main/java/org/sopt/domain/Like.java
+++ b/src/main/java/org/sopt/domain/Like.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.sopt.domain.enums.LikeType;
 
+@Table(name = "likes")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Like {

--- a/src/main/java/org/sopt/domain/Like.java
+++ b/src/main/java/org/sopt/domain/Like.java
@@ -3,6 +3,7 @@ package org.sopt.domain;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.sopt.domain.enums.LikeType;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -10,6 +11,9 @@ public class Like {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private LikeType likeType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/org/sopt/domain/Like.java
+++ b/src/main/java/org/sopt/domain/Like.java
@@ -1,0 +1,26 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Like {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+}

--- a/src/main/java/org/sopt/domain/Like.java
+++ b/src/main/java/org/sopt/domain/Like.java
@@ -27,4 +27,25 @@ public class Like {
     @JoinColumn(name = "post_id")
     private Post post;
 
+    private Like(User user, Post post, LikeType likeType) {
+        this.user = user;
+        this.post = post;
+        this.likeType = likeType;
+    }
+
+    private Like(User user, Comment comment, LikeType likeType) {
+        this.user = user;
+        this.comment = comment;
+        this.likeType = likeType;
+    }
+
+    public static Like forComment(User user, Comment comment){
+        return new Like(user, comment, LikeType.COMMENT);
+    }
+
+    public static Like forPost(User user, Post post){
+        return new Like(user, post, LikeType.POST);
+    }
+
+
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -26,10 +26,10 @@ public class Post extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PostType postType;
 
-    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "like", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Like> likes = new ArrayList<>();
 
     public Post(String title, String content, User user, PostType postType) {

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import org.sopt.domain.common.BaseTimeEntity;
 import org.sopt.domain.enums.PostType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 public class Post extends BaseTimeEntity {
 
@@ -22,6 +25,12 @@ public class Post extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private PostType postType;
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "like", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Like> likes = new ArrayList<>();
 
     public Post(String title, String content, User user, PostType postType) {
         this.title = title;

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -23,8 +23,8 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Enumerated(EnumType.STRING)
-    private PostType postType;
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
+    private List<Tag> tag;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();
@@ -32,11 +32,10 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Like> likes = new ArrayList<>();
 
-    public Post(String title, String content, User user, PostType postType) {
+    public Post(String title, String content, User user) {
         this.title = title;
         this.content = content;
         this.user = user;
-        this.postType = postType;
     }
 
     public Post() {

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -1,12 +1,15 @@
 package org.sopt.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.sopt.domain.common.BaseTimeEntity;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,10 +40,6 @@ public class Post extends BaseTimeEntity {
         this.user = user;
     }
 
-    public Post() {
-
-    }
-
     public Long getId() {
         return this.id;
     }
@@ -61,12 +60,11 @@ public class Post extends BaseTimeEntity {
         this.content = content;
     }
 
-    public void updatePost(String content, String title) {
-        this.content = content;
-        this.title = title;
-    }
-
     public User getUser() {
         return user;
+    }
+
+    public void addPostTag(PostTag postTag) {
+        this.postTags.add(postTag);
     }
 }

--- a/src/main/java/org/sopt/domain/Post.java
+++ b/src/main/java/org/sopt/domain/Post.java
@@ -2,7 +2,6 @@ package org.sopt.domain;
 
 import jakarta.persistence.*;
 import org.sopt.domain.common.BaseTimeEntity;
-import org.sopt.domain.enums.PostType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,8 +22,8 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY)
-    private List<Tag> tag;
+    @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PostTag> postTags = new ArrayList<>();
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Comment> comments = new ArrayList<>();

--- a/src/main/java/org/sopt/domain/PostTag.java
+++ b/src/main/java/org/sopt/domain/PostTag.java
@@ -1,0 +1,30 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.sopt.domain.common.BaseTimeEntity;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostTag extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tag_id")
+    private Tag tag;
+
+    public PostTag(Post post, Tag tag){
+        this.post = post;
+        this.tag = tag;
+    }
+    public static PostTag createPostTag(Post post, Tag tag){
+        return new PostTag(post, tag);
+    }
+}

--- a/src/main/java/org/sopt/domain/Tag.java
+++ b/src/main/java/org/sopt/domain/Tag.java
@@ -1,0 +1,20 @@
+package org.sopt.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.sopt.domain.enums.PostType;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private PostType postType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+}

--- a/src/main/java/org/sopt/domain/Tag.java
+++ b/src/main/java/org/sopt/domain/Tag.java
@@ -3,7 +3,9 @@ package org.sopt.domain;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.sopt.domain.enums.PostType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,10 +13,9 @@ public class Tag {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    private PostType postType;
+    @Column(nullable = false)
+    private String name;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
+    @OneToMany(mappedBy = "tag", fetch = FetchType.LAZY)
+    private List<PostTag> postTags = new ArrayList<>();
 }

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -2,6 +2,9 @@ package org.sopt.domain;
 
 import jakarta.persistence.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 public class User {
 
@@ -11,12 +14,14 @@ public class User {
     @Column(nullable = false)
     String name;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    private List<Post> posts = new ArrayList<>();
+
     public User(String name){
         this.name = name;
     }
 
     public User() {
-
     }
 
     public String getName(){

--- a/src/main/java/org/sopt/domain/User.java
+++ b/src/main/java/org/sopt/domain/User.java
@@ -14,7 +14,7 @@ public class User {
     @Column(nullable = false)
     String name;
 
-    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, fetch = FetchType.LAZY)
     private List<Post> posts = new ArrayList<>();
 
     public User(String name){

--- a/src/main/java/org/sopt/domain/enums/LikeType.java
+++ b/src/main/java/org/sopt/domain/enums/LikeType.java
@@ -1,0 +1,5 @@
+package org.sopt.domain.enums;
+
+public enum LikeType {
+    COMMENT, POST
+}

--- a/src/main/java/org/sopt/domain/enums/PostType.java
+++ b/src/main/java/org/sopt/domain/enums/PostType.java
@@ -1,5 +1,0 @@
-package org.sopt.domain.enums;
-
-public enum PostType {
-    BACKEND, DATABASE, INFRA, ETC
-}

--- a/src/main/java/org/sopt/domain/enums/PostType.java
+++ b/src/main/java/org/sopt/domain/enums/PostType.java
@@ -1,5 +1,5 @@
 package org.sopt.domain.enums;
 
 public enum PostType {
-    BACKEND, DATABASE, INFRA
+    BACKEND, DATABASE, INFRA, ETC
 }

--- a/src/main/java/org/sopt/dto/CommentIdResponse.java
+++ b/src/main/java/org/sopt/dto/CommentIdResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.dto;
+
+public record CommentIdResponse(
+        Long id
+) {
+    public static CommentIdResponse of(Long id){
+        return new CommentIdResponse(id);
+    }
+}

--- a/src/main/java/org/sopt/dto/CommentRequest.java
+++ b/src/main/java/org/sopt/dto/CommentRequest.java
@@ -1,0 +1,11 @@
+package org.sopt.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+public record CommentRequest(
+        @NotEmpty(message = "댓글은 비어있을 수 없습니다.")
+        @Size(message = "댓글은 300자 이내로 작성할 수 있습니다.", max = 300)
+        String content
+) {
+}

--- a/src/main/java/org/sopt/dto/CommentResponse.java
+++ b/src/main/java/org/sopt/dto/CommentResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.dto;
+
+import org.sopt.domain.Comment;
+
+public record CommentResponse(
+        Long userId,
+        String content
+) {
+    public static CommentResponse of(Comment comment){
+        return new CommentResponse(comment.getUser().getId(), comment.getContent());
+    }
+}

--- a/src/main/java/org/sopt/dto/LoginRequest.java
+++ b/src/main/java/org/sopt/dto/LoginRequest.java
@@ -2,9 +2,10 @@ package org.sopt.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record LoginRequest(
-        @NotEmpty(message = "id는 비어있을 수 없습니다.")
+        @NotNull(message = "id는 비어있을 수 없습니다.")
         Long userId,
         @NotBlank(message = "이름은 비어있을 수 없습니다.")
         String name

--- a/src/main/java/org/sopt/dto/LoginRequest.java
+++ b/src/main/java/org/sopt/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package org.sopt.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+public record LoginRequest(
+        @NotEmpty(message = "id는 비어있을 수 없습니다.")
+        Long userId,
+        @NotBlank(message = "이름은 비어있을 수 없습니다.")
+        String name
+) {
+}

--- a/src/main/java/org/sopt/dto/LoginRequest.java
+++ b/src/main/java/org/sopt/dto/LoginRequest.java
@@ -1,7 +1,6 @@
 package org.sopt.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record LoginRequest(

--- a/src/main/java/org/sopt/dto/LoginResponse.java
+++ b/src/main/java/org/sopt/dto/LoginResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.dto;
+
+public record LoginResponse(
+        String accessToken
+) {
+    public static LoginResponse of(String accessToken){
+        return new LoginResponse(accessToken);
+    }
+}

--- a/src/main/java/org/sopt/dto/PostAllResponse.java
+++ b/src/main/java/org/sopt/dto/PostAllResponse.java
@@ -1,11 +1,22 @@
 package org.sopt.dto;
 
+import org.sopt.domain.Post;
+import org.springframework.data.domain.Page;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record PostAllResponse(
+        int totalElements,
+        int totalPages,
         List<PostListResponse> contentList
 ) {
-    public static PostAllResponse from(List<PostListResponse> contentList){
-        return new PostAllResponse(contentList);
+    public static PostAllResponse from(Page<Post> postPage){
+        return new PostAllResponse(
+                (int) postPage.getTotalElements(),
+                postPage.getTotalPages(),
+                postPage.stream().map(PostListResponse::from)
+                        .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/org/sopt/dto/PostAllResponse.java
+++ b/src/main/java/org/sopt/dto/PostAllResponse.java
@@ -19,4 +19,5 @@ public record PostAllResponse(
                         .collect(Collectors.toList())
         );
     }
+
 }

--- a/src/main/java/org/sopt/dto/PostRequest.java
+++ b/src/main/java/org/sopt/dto/PostRequest.java
@@ -2,13 +2,15 @@ package org.sopt.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.List;
+
 public record PostRequest(
         @NotBlank(message = "제목은 비어있을 수 없습니다.")
         String title,
         @NotBlank(message = "내용은 비어있을 수 없습니다.")
         String content,
         @NotBlank(message = "태그는 비어있을 수 없습니다.")
-        String postType
+        List<String> postType
 ) {
 
 }

--- a/src/main/java/org/sopt/dto/PostRequest.java
+++ b/src/main/java/org/sopt/dto/PostRequest.java
@@ -1,6 +1,7 @@
 package org.sopt.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
@@ -9,7 +10,7 @@ public record PostRequest(
         String title,
         @NotBlank(message = "내용은 비어있을 수 없습니다.")
         String content,
-        @NotBlank(message = "태그는 비어있을 수 없습니다.")
+        @NotEmpty(message = "태그는 비어있을 수 없습니다.")
         List<String> postType
 ) {
 

--- a/src/main/java/org/sopt/dto/PostResponse.java
+++ b/src/main/java/org/sopt/dto/PostResponse.java
@@ -2,13 +2,16 @@ package org.sopt.dto;
 
 import org.sopt.domain.Post;
 
+import java.util.List;
+
 public record PostResponse(
         String title,
         Long contentId,
         String writer,
-        String content
+        String content,
+        List<CommentResponse> commentResponses
 ) {
-    public static PostResponse from(Post post){
-        return new PostResponse(post.getTitle(), post.getId(), post.getUser().getName(), post.getContent());
+    public static PostResponse from(Post post, List<CommentResponse> commentResponses){
+        return new PostResponse(post.getTitle(), post.getId(), post.getUser().getName(), post.getContent(), commentResponses);
     }
 }

--- a/src/main/java/org/sopt/dto/PostSearchResponse.java
+++ b/src/main/java/org/sopt/dto/PostSearchResponse.java
@@ -1,0 +1,12 @@
+package org.sopt.dto;
+
+import java.util.List;
+
+public record PostSearchResponse(
+        List<PostListResponse> contentList
+
+) {
+    public static PostSearchResponse from(List<PostListResponse> postList){
+        return new PostSearchResponse(postList);
+    }
+}

--- a/src/main/java/org/sopt/dto/PostUpdateRequest.java
+++ b/src/main/java/org/sopt/dto/PostUpdateRequest.java
@@ -1,7 +1,11 @@
 package org.sopt.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record PostUpdateRequest(
+        @NotBlank(message = "제목은 비어있을 수 없습니다.")
         String title,
+        @NotBlank(message = "내용은 비어있을 수 없습니다.")
         String content
 
 ) {

--- a/src/main/java/org/sopt/dto/ToggleLikeRequest.java
+++ b/src/main/java/org/sopt/dto/ToggleLikeRequest.java
@@ -7,6 +7,6 @@ public record ToggleLikeRequest(
         @NotNull(message = "댓글 또는 게시글 ID는 null일 수 없습니다.")
         Long id,
         @NotNull(message = "좋아요 타입은 null일 수 없습니다.")
-        LikeType likeType
+        String likeType
 ) {
 }

--- a/src/main/java/org/sopt/dto/ToggleLikeRequest.java
+++ b/src/main/java/org/sopt/dto/ToggleLikeRequest.java
@@ -1,0 +1,12 @@
+package org.sopt.dto;
+
+import jakarta.validation.constraints.NotNull;
+import org.sopt.domain.enums.LikeType;
+
+public record ToggleLikeRequest(
+        @NotNull(message = "댓글 또는 게시글 ID는 null일 수 없습니다.")
+        Long id,
+        @NotNull(message = "좋아요 타입은 null일 수 없습니다.")
+        LikeType likeType
+) {
+}

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import jakarta.validation.ConstraintViolationException;
 import org.sopt.common.CommonApiResponse;
 import org.sopt.common.CommonErrorCode;
 import org.sopt.common.ErrorCode;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
@@ -26,8 +27,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
         ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+
+        String message = e.getBindingResult().getAllErrors().stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse(errorCode.getMessage());
+
         return ResponseEntity.status(errorCode.getHttpStatus())
-                .body(CommonApiResponse.onFailure(errorCode));
+                .body(CommonApiResponse.onFailure(errorCode, message));
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)

--- a/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/exception/GlobalExceptionHandler.java
@@ -1,8 +1,13 @@
 package org.sopt.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import org.sopt.common.CommonApiResponse;
+import org.sopt.common.CommonErrorCode;
 import org.sopt.common.ErrorCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,6 +18,29 @@ public class GlobalExceptionHandler {
     public ResponseEntity<CommonApiResponse<?>> handleCustomException(CustomException ex) {
         ErrorCode errorCode = ex.getErrorCode();
 
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(CommonApiResponse.onFailure(errorCode));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        ErrorCode errorCode = CommonErrorCode.INVALID_INPUT_VALUE;
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(CommonApiResponse.onFailure(errorCode));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<CommonApiResponse<Void>> handleMissingServletRequestParameterException(MissingServletRequestParameterException e){
+        ErrorCode errorCode = CommonErrorCode.MISSING_PARAMETER;
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(CommonApiResponse.onFailure(errorCode));
+    }
+
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonApiResponse<Void>> handleUnexpectedException(Exception e) {
+        ErrorCode errorCode = CommonErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(CommonApiResponse.onFailure(errorCode));

--- a/src/main/java/org/sopt/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/org/sopt/repository/CommentRepository.java
+++ b/src/main/java/org/sopt/repository/CommentRepository.java
@@ -1,7 +1,12 @@
 package org.sopt.repository;
 
 import org.sopt.domain.Comment;
+import org.sopt.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> getAllByPost(Post post);
 }

--- a/src/main/java/org/sopt/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/repository/LikeRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+}

--- a/src/main/java/org/sopt/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/repository/LikeRepository.java
@@ -2,6 +2,7 @@ package org.sopt.repository;
 
 import org.sopt.domain.Comment;
 import org.sopt.domain.Like;
+import org.sopt.domain.Post;
 import org.sopt.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,6 @@ import java.util.Optional;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
     Optional<Like> findByUserAndComment(User user, Comment comment);
+    Optional<Like> findByUserAndPost(User user, Post post);
+
 }

--- a/src/main/java/org/sopt/repository/LikeRepository.java
+++ b/src/main/java/org/sopt/repository/LikeRepository.java
@@ -1,7 +1,12 @@
 package org.sopt.repository;
 
+import org.sopt.domain.Comment;
 import org.sopt.domain.Like;
+import org.sopt.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByUserAndComment(User user, Comment comment);
 }

--- a/src/main/java/org/sopt/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/repository/PostCustomRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Post;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface PostCustomRepository {
+
+    List<Post> searchByTitleOrUserName(String keyworde);
+}

--- a/src/main/java/org/sopt/repository/PostCustomRepository.java
+++ b/src/main/java/org/sopt/repository/PostCustomRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface PostCustomRepository {
 
     List<Post> searchByTitleOrUserName(String keyworde);
+
+    List<Post> searchByTag(String tag);
 }

--- a/src/main/java/org/sopt/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/repository/PostCustomRepositoryImpl.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 
 import static org.sopt.domain.QPost.post;
 import static org.sopt.domain.QUser.user;
+import static org.sopt.domain.QPostTag.postTag;
+import static org.sopt.domain.QTag.tag;
 
 
 import java.util.List;
@@ -27,4 +29,16 @@ public class PostCustomRepositoryImpl implements PostCustomRepository{
                 )
                 .fetch();
     }
+
+    @Override
+    public List<Post> searchByTag(String tagName) {
+        return jpaQueryFactory
+                .select(post)
+                .from(postTag)
+                .join(postTag.post, post)
+                .join(postTag.tag, tag)
+                .where(tag.name.eq(tagName))
+                .fetch();
+    }
+
 }

--- a/src/main/java/org/sopt/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/org/sopt/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package org.sopt.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Post;
+import org.springframework.stereotype.Repository;
+
+import static org.sopt.domain.QPost.post;
+import static org.sopt.domain.QUser.user;
+
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> searchByTitleOrUserName(String keyword) {
+        return jpaQueryFactory.selectFrom(post)
+                .join(post.user, user)
+                .where(
+                        post.title.contains(keyword)
+                                .or(user.name.eq(keyword))
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -2,6 +2,8 @@ package org.sopt.repository;
 
 import org.sopt.domain.Post;
 import org.sopt.domain.enums.PostType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +17,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> searchByTitleOrUserName(@Param("keyword") String keyword);
 
     List<Post> findByPostType(PostType postType);
+
+    Page<Post> findAllByOOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -18,5 +18,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findByPostType(PostType postType);
 
-    Page<Post> findAllByOOrderByCreatedAtDesc(Pageable pageable);
+    Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -1,14 +1,9 @@
 package org.sopt.repository;
 
 import org.sopt.domain.Post;
-import org.sopt.domain.enums.PostType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     boolean existsByTitle(String title);
@@ -16,7 +11,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     /*@Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.user.name LIKE %:keyword%")
     List<Post> searchByTitleOrUserName(@Param("keyword") String keyword);*/
 
-    List<Post> findByPostType(PostType postType);
+    //List<Post> findByPostType(PostType postType);
 
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }

--- a/src/main/java/org/sopt/repository/PostRepository.java
+++ b/src/main/java/org/sopt/repository/PostRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 public interface PostRepository extends JpaRepository<Post, Long> {
     boolean existsByTitle(String title);
 
-    @Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.user.name LIKE %:keyword%")
-    List<Post> searchByTitleOrUserName(@Param("keyword") String keyword);
+    /*@Query("SELECT p FROM Post p WHERE p.title LIKE %:keyword% OR p.user.name LIKE %:keyword%")
+    List<Post> searchByTitleOrUserName(@Param("keyword") String keyword);*/
 
     List<Post> findByPostType(PostType postType);
 

--- a/src/main/java/org/sopt/repository/TagRepository.java
+++ b/src/main/java/org/sopt/repository/TagRepository.java
@@ -1,0 +1,11 @@
+package org.sopt.repository;
+
+import org.sopt.domain.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String postType);
+}

--- a/src/main/java/org/sopt/repository/UserRepository.java
+++ b/src/main/java/org/sopt/repository/UserRepository.java
@@ -3,5 +3,9 @@ package org.sopt.repository;
 import org.sopt.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByIdAndName(Long id, String name);
 }

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -25,7 +25,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     public static final String[] AUTH_WHITELIST = {
-            "/api/v1/auth/login",
+            "/api/v1/auth/login"
     };
 
     public static final String[] SWAGGER_WHITELIST = {

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     public static final String[] AUTH_WHITELIST = {
-            "/api/v1/auth/login"
+            "/api/v1/auth/login",
+            "/api/v1/contents/search",
     };
 
     public static final String[] SWAGGER_WHITELIST = {

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -1,0 +1,71 @@
+package org.sopt.security.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.sopt.security.filter.JwtAuthenticationFilter;
+import org.sopt.security.filter.JwtExceptionFilter;
+import org.sopt.security.handler.JwtAuthenticationEntryPoint;
+import org.sopt.utils.JwtUtil;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    public static final String[] AUTH_WHITELIST = {
+            "/api/v1/auth/login",
+    };
+
+    public static final String[] SWAGGER_WHITELIST = {
+            "/swagger",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/api-docs",
+            "/api-docs/**",
+            "/v3/api-docs/**"
+    };
+
+    @Bean
+    public JwtExceptionFilter jwtExceptionFilter() {
+        return new JwtExceptionFilter(objectMapper); // 생성자에 objectMapper를 넘겨줌
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.sameOrigin()) //h2/console 띄우기 위해 필요
+                )
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement ->
+                        sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .requestMatchers(SWAGGER_WHITELIST).permitAll()
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+
+                // Bean으로 등록된 jwtExceptionFilter()를 호출
+                .addFilterBefore(jwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -46,9 +46,6 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())  // CSRF 보호 비활성화
-                .headers(headers -> headers
-                        .frameOptions(frame -> frame.sameOrigin()) //h2/console 띄우기 위해 필요
-                )
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(sessionManagement ->

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -26,7 +26,6 @@ public class SecurityConfig {
 
     public static final String[] AUTH_WHITELIST = {
             "/api/v1/auth/login",
-            "/api/v1/contents/search",
     };
 
     public static final String[] SWAGGER_WHITELIST = {

--- a/src/main/java/org/sopt/security/config/SecurityConfig.java
+++ b/src/main/java/org/sopt/security/config/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
 
     public static final String[] AUTH_WHITELIST = {
             "/api/v1/auth/login",
+            "/api/v1/user/signup"
     };
 
     public static final String[] SWAGGER_WHITELIST = {

--- a/src/main/java/org/sopt/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package org.sopt.security.filter;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.utils.JwtUtil;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String BEARER_PREFIX = "Bearer ";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private final JwtUtil jwtUtil;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+            final String token = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(token)){
+                Claims claims = jwtUtil.getTokenBody(token);
+
+                Long userId = claims.get("userId", Long.class);
+                Authentication auth = new UsernamePasswordAuthenticationToken(userId, null, List.of());
+
+                SecurityContextHolder.getContext().setAuthentication(auth); // 현재 요청에 대한 인증 정보를 Spring Security의 SecurityContext에 저장
+
+            }
+            filterChain.doFilter(request, response);
+
+        }
+
+        private String getJwtFromRequest(HttpServletRequest request){
+            String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+            if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
+                return bearerToken.substring(BEARER_PREFIX.length());
+            }
+            return null;
+        }
+}

--- a/src/main/java/org/sopt/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/security/filter/JwtAuthenticationFilter.java
@@ -50,7 +50,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
 
             if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)){
-                return bearerToken.substring(BEARER_PREFIX.length());
+                //TODO : trim() 여부
+                return bearerToken.substring(BEARER_PREFIX.length()).trim();
             }
             return null;
         }

--- a/src/main/java/org/sopt/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/org/sopt/security/filter/JwtAuthenticationFilter.java
@@ -5,7 +5,10 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.utils.JwtUtil;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -17,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     public static final String BEARER_PREFIX = "Bearer ";
@@ -26,7 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
 
             final String token = getJwtFromRequest(request);
 
@@ -40,7 +44,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             }
             filterChain.doFilter(request, response);
-
         }
 
         private String getJwtFromRequest(HttpServletRequest request){

--- a/src/main/java/org/sopt/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/org/sopt/security/filter/JwtExceptionFilter.java
@@ -1,0 +1,49 @@
+package org.sopt.security.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.AuthErrorCode;
+import org.sopt.common.CommonErrorCode;
+import org.sopt.common.ErrorCode;
+import org.sopt.exception.CustomException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    private final ObjectMapper objectMapper;
+
+    protected void doFilterInternal(
+            @NonNull final HttpServletRequest request,
+            @NonNull final HttpServletResponse response,
+            @NonNull final FilterChain filterChain) throws IOException, ServletException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (MalformedJwtException e) {
+            request.setAttribute("exception", AuthErrorCode.TOKEN_MALFORMED_ERROR);
+        } catch (IllegalArgumentException e) {
+            request.setAttribute("exception", AuthErrorCode.TOKEN_TYPE_ERROR);
+        } catch (ExpiredJwtException e) {
+            request.setAttribute("exception", AuthErrorCode.EXPIRED_TOKEN_ERROR);
+        } catch (UnsupportedJwtException e) {
+            request.setAttribute("exception", AuthErrorCode.TOKEN_UNSUPPORTED_ERROR);
+        } catch (JwtException e) {
+            request.setAttribute("exception", AuthErrorCode.TOKEN_UNKNOWN_ERROR);
+        } catch (CustomException e) {
+            request.setAttribute("exception", e.getErrorCode());
+        } catch (Exception e) {
+            request.setAttribute("exception", CommonErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/sopt/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/security/handler/JwtAuthenticationEntryPoint.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.common.AuthErrorCode;
 import org.sopt.common.CommonApiResponse;
 import org.sopt.common.ErrorCode;
@@ -16,13 +17,15 @@ import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
     private final ObjectMapper objectMapper;
 
-    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException {
         ErrorCode errorCode = (ErrorCode) request.getAttribute("exception");
         if (errorCode == null) {
+            log.info("auth");
             errorCode = AuthErrorCode.UNAUTHORIZED;
         }
 

--- a/src/main/java/org/sopt/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/security/handler/JwtAuthenticationEntryPoint.java
@@ -25,7 +25,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException {
         ErrorCode errorCode = (ErrorCode) request.getAttribute("exception");
         if (errorCode == null) {
-            log.info("auth");
+            log.info("auth error");
             errorCode = AuthErrorCode.UNAUTHORIZED;
         }
 

--- a/src/main/java/org/sopt/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/security/handler/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,40 @@
+package org.sopt.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.AuthErrorCode;
+import org.sopt.common.CommonApiResponse;
+import org.sopt.common.ErrorCode;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.naming.AuthenticationException;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    public void commence(HttpServletRequest request, HttpServletResponse response, org.springframework.security.core.AuthenticationException authException) throws IOException, ServletException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("exception");
+        if (errorCode == null) {
+            errorCode = AuthErrorCode.UNAUTHORIZED;
+        }
+
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getHttpStatus().value());
+
+        CommonApiResponse<?> baseResponse = CommonApiResponse.onFailure(errorCode);
+
+        // JSON 직렬화
+        response.getWriter().write(
+                objectMapper.writeValueAsString(baseResponse)
+        );
+    }
+}

--- a/src/main/java/org/sopt/service/AuthService.java
+++ b/src/main/java/org/sopt/service/AuthService.java
@@ -1,0 +1,20 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.User;
+import org.sopt.dto.LoginRequest;
+import org.sopt.dto.LoginResponse;
+import org.sopt.utils.JwtUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserReader userReader;
+    private final JwtUtil jwtUtil;
+
+    public LoginResponse login(LoginRequest request){
+        User findUser = userReader.findByIdAndName(request.userId(), request.name());
+            return jwtUtil.generateToken(findUser.getId());
+    }
+}

--- a/src/main/java/org/sopt/service/CommentFinder.java
+++ b/src/main/java/org/sopt/service/CommentFinder.java
@@ -1,0 +1,21 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Comment;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.CommentRepository;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.common.CommentErrorCode.COMMENT_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class CommentFinder {
+
+    private final CommentRepository commentRepository;
+
+    public Comment getById(Long commentId){
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/service/CommentReader.java
+++ b/src/main/java/org/sopt/service/CommentReader.java
@@ -2,9 +2,12 @@ package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.Comment;
+import org.sopt.domain.Post;
 import org.sopt.exception.CustomException;
 import org.sopt.repository.CommentRepository;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static org.sopt.common.CommentErrorCode.COMMENT_NOT_FOUND;
 
@@ -17,5 +20,9 @@ public class CommentReader {
     public Comment getById(Long commentId){
         return commentRepository.findById(commentId)
                 .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
+    }
+
+    public List<Comment> getAllByPost(Post post){
+        return commentRepository.getAllByPost(post);
     }
 }

--- a/src/main/java/org/sopt/service/CommentReader.java
+++ b/src/main/java/org/sopt/service/CommentReader.java
@@ -10,7 +10,7 @@ import static org.sopt.common.CommentErrorCode.COMMENT_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
-public class CommentFinder {
+public class CommentReader {
 
     private final CommentRepository commentRepository;
 

--- a/src/main/java/org/sopt/service/CommentSaver.java
+++ b/src/main/java/org/sopt/service/CommentSaver.java
@@ -1,0 +1,17 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Comment;
+import org.sopt.repository.CommentRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentSaver {
+
+    private final CommentRepository commentRepository;
+
+    public Comment save(Comment comment){
+        return commentRepository.save(comment);
+    }
+}

--- a/src/main/java/org/sopt/service/CommentService.java
+++ b/src/main/java/org/sopt/service/CommentService.java
@@ -6,42 +6,26 @@ import org.sopt.domain.Post;
 import org.sopt.domain.User;
 import org.sopt.dto.CommentIdResponse;
 import org.sopt.dto.CommentRequest;
-import org.sopt.exception.CustomException;
-import org.sopt.repository.CommentRepository;
-import org.sopt.repository.PostRepository;
-import org.sopt.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import static org.sopt.common.PostErrorCode.POST_NOT_FOUND;
-import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
-    private final CommentRepository commentRepository;
-    private final UserRepository userRepository;
-    private final PostRepository postRepository;
+    private final PostReader postReader;
+    private final UserReader userReader;
+    private final CommentSaver commentSaver;
 
     @Transactional
     public CommentIdResponse createComment(CommentRequest request, Long userId, Long postId){
 
-        User findUser = validateUser(userId);
-        Post findPost = validatePost(postId);
+        User findUser = userReader.getById(userId);
+        Post findPost = postReader.getById(postId);
 
         Comment newComment = Comment.createComment(request.content(), findUser, findPost);
-        Long newCommentId = commentRepository.save(newComment).getId();
+        Long newCommentId = commentSaver.save(newComment).getId();
         return CommentIdResponse.of(newCommentId);
     }
 
-    private User validateUser(Long userId){
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
-    }
-
-    private Post validatePost(Long postId){
-        return postRepository.findById(postId)
-                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-    }
 }

--- a/src/main/java/org/sopt/service/CommentService.java
+++ b/src/main/java/org/sopt/service/CommentService.java
@@ -1,0 +1,47 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Comment;
+import org.sopt.domain.Post;
+import org.sopt.domain.User;
+import org.sopt.dto.CommentIdResponse;
+import org.sopt.dto.CommentRequest;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.CommentRepository;
+import org.sopt.repository.PostRepository;
+import org.sopt.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.sopt.common.PostErrorCode.POST_NOT_FOUND;
+import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public CommentIdResponse createComment(CommentRequest request, Long userId, Long postId){
+
+        User findUser = validateUser(userId);
+        Post findPost = validatePost(postId);
+
+        Comment newComment = Comment.createComment(request.content(), findUser, findPost);
+        Long newCommentId = commentRepository.save(newComment).getId();
+        return CommentIdResponse.of(newCommentId);
+    }
+
+    private User validateUser(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    private Post validatePost(Long postId){
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/service/LikeFinder.java
+++ b/src/main/java/org/sopt/service/LikeFinder.java
@@ -1,0 +1,22 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Comment;
+import org.sopt.domain.Like;
+import org.sopt.domain.User;
+import org.sopt.repository.LikeRepository;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class LikeFinder {
+
+    private final LikeRepository likeRepository;
+
+    public Optional<Like> findByUserAndComment(User user, Comment comment){
+        return likeRepository.findByUserAndComment(user, comment);
+    }
+
+}

--- a/src/main/java/org/sopt/service/LikeReader.java
+++ b/src/main/java/org/sopt/service/LikeReader.java
@@ -3,6 +3,7 @@ package org.sopt.service;
 import lombok.RequiredArgsConstructor;
 import org.sopt.domain.Comment;
 import org.sopt.domain.Like;
+import org.sopt.domain.Post;
 import org.sopt.domain.User;
 import org.sopt.repository.LikeRepository;
 import org.springframework.stereotype.Component;
@@ -11,12 +12,16 @@ import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
-public class LikeFinder {
+public class LikeReader {
 
     private final LikeRepository likeRepository;
 
     public Optional<Like> findByUserAndComment(User user, Comment comment){
         return likeRepository.findByUserAndComment(user, comment);
+    }
+
+    public Optional<Like> findByUserAndPost(User user, Post post){
+        return likeRepository.findByUserAndPost(user, post);
     }
 
 }

--- a/src/main/java/org/sopt/service/LikeRemover.java
+++ b/src/main/java/org/sopt/service/LikeRemover.java
@@ -1,0 +1,17 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Like;
+import org.sopt.repository.LikeRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LikeRemover {
+
+    private final LikeRepository likeRepository;
+
+    public void delete(Like like){
+        likeRepository.delete(like);
+    }
+}

--- a/src/main/java/org/sopt/service/LikeSaver.java
+++ b/src/main/java/org/sopt/service/LikeSaver.java
@@ -1,0 +1,9 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LikeSaver {
+}

--- a/src/main/java/org/sopt/service/LikeSaver.java
+++ b/src/main/java/org/sopt/service/LikeSaver.java
@@ -1,9 +1,16 @@
 package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Like;
+import org.sopt.repository.LikeRepository;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class LikeSaver {
+    private final LikeRepository likeRepository;
+
+    public void save(Like like){
+        likeRepository.save(like);
+    }
 }

--- a/src/main/java/org/sopt/service/LikeService.java
+++ b/src/main/java/org/sopt/service/LikeService.java
@@ -31,7 +31,7 @@ public class LikeService {
 
     private void toggle(ToggleLikeRequest request, User user){
 
-        if (request.likeType() == LikeType.COMMENT){
+        if (LikeType.valueOf(request.likeType()) == LikeType.COMMENT){
             Comment findComment = commentFinder.getById(request.id());
             Optional<Like> likeOptional = likeFinder.findByUserAndComment(user, findComment);
 

--- a/src/main/java/org/sopt/service/LikeService.java
+++ b/src/main/java/org/sopt/service/LikeService.java
@@ -1,0 +1,41 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Comment;
+import org.sopt.domain.Like;
+import org.sopt.domain.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final UserReader userReader;
+    private final CommentFinder commentFinder;
+    private final LikeFinder likeFinder;
+    private final LikeRemover likeRemover;
+
+    @Transactional
+    public void toggleCommentLike(Long memberId, Long commentId){
+        User findUser = userReader.getById(memberId);
+        Comment findComment = commentFinder.getById(commentId);
+
+
+    }
+
+    private boolean toggleComment(Comment comment, User user){
+        Optional<Like> likeOptional = likeFinder.findByUserAndComment(user, comment);
+
+        if (likeOptional.isPresent()) {
+            likeRemover.delete(likeOptional.get());
+        } else {
+            likeSa
+        }
+    }
+
+
+
+}

--- a/src/main/java/org/sopt/service/PostReader.java
+++ b/src/main/java/org/sopt/service/PostReader.java
@@ -1,0 +1,23 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.Post;
+import org.sopt.domain.User;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.PostRepository;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.common.PostErrorCode.POST_NOT_FOUND;
+import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class PostReader {
+
+    private final PostRepository postRepository;
+
+    public Post getById(Long postId){
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/service/PostReader.java
+++ b/src/main/java/org/sopt/service/PostReader.java
@@ -27,4 +27,8 @@ public class PostReader {
     public List<Post> searchByTitleOrUserName(String keyword){
         return postCustomRepository.searchByTitleOrUserName(keyword);
     }
+
+    public List<Post> searchByTag(String tagName){
+        return postCustomRepository.searchByTag(tagName);
+    }
 }

--- a/src/main/java/org/sopt/service/PostReader.java
+++ b/src/main/java/org/sopt/service/PostReader.java
@@ -4,20 +4,27 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.domain.Post;
 import org.sopt.domain.User;
 import org.sopt.exception.CustomException;
+import org.sopt.repository.PostCustomRepository;
 import org.sopt.repository.PostRepository;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 import static org.sopt.common.PostErrorCode.POST_NOT_FOUND;
-import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
 public class PostReader {
 
     private final PostRepository postRepository;
+    private final PostCustomRepository postCustomRepository;
 
     public Post getById(Long postId){
         return postRepository.findById(postId)
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+    }
+
+    public List<Post> searchByTitleOrUserName(String keyword){
+        return postCustomRepository.searchByTitleOrUserName(keyword);
     }
 }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -51,7 +51,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostResponse getPostById(Long id) {
         Post post = postRepository.findById(id)
-                .orElseThrow(() -> new CustomException(EMPTY_POST));
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
 
         return PostResponse.from(post);
     }
@@ -59,7 +59,7 @@ public class PostService {
     @Transactional
     public void deletePostById(Long id, Long userId) {
         Post post = postRepository.findById(id)
-                .orElseThrow(() -> new CustomException(EMPTY_POST));
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
 
         if (!post.getUser().getId().equals(userId))
             throw new CustomException(USER_UNAUTHORIZED);
@@ -71,7 +71,7 @@ public class PostService {
     public PostResponse updatePost(Long id, PostUpdateRequest request, Long userId){
         validateTitle(request.title());
         Post post = postRepository.findById(id)
-                .orElseThrow(() -> new CustomException(EMPTY_POST));
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
 
         if (!post.getUser().getId().equals(userId))
             throw new CustomException(USER_UNAUTHORIZED);

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -48,7 +48,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostAllResponse getAllPosts(int size, int page) {
         Pageable pageable = PageRequest.of(size, page);
-        Page<Post> postPage = postRepository.findAllByOOrderByCreatedAtDesc(pageable);
+        Page<Post> postPage = postRepository.findAllByOrderByCreatedAtDesc(pageable);
 
         return PostAllResponse.from(postPage);
     }
@@ -95,23 +95,23 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostAllResponse searchPostsByKeyword(String keyword){
+    public PostSearchResponse searchPostsByKeyword(String keyword){
 
         List<PostListResponse> postResponses = postRepository.findAll().stream()
                 .map(PostListResponse::from)
                 .toList();
 
-        return PostAllResponse.from(postResponses);
+        return PostSearchResponse.from(postResponses);
     }
 
     @Transactional(readOnly = true)
-    public PostAllResponse searchPostsByTag(String tag){
+    public PostSearchResponse searchPostsByTag(String tag){
 
         List<PostListResponse> postResponses = postRepository.findAll().stream()
                 .map(PostListResponse::from)
                 .toList();
 
-        return PostAllResponse.from(postResponses);
+        return PostSearchResponse.from(postResponses);
     }
 
     private void validateTitle(String title){

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -8,6 +8,9 @@ import org.sopt.dto.*;
 import org.sopt.exception.CustomException;
 import org.sopt.repository.PostRepository;
 import org.sopt.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,12 +46,11 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostAllResponse getAllPosts() {
-        List<PostListResponse> postResponses = postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdAt")).stream()
-                .map(PostListResponse::from)
-                .toList();
+    public PostAllResponse getAllPosts(int size, int page) {
+        Pageable pageable = PageRequest.of(size, page);
+        Page<Post> postPage = postRepository.findAllByOOrderByCreatedAtDesc(pageable);
 
-        return PostAllResponse.from(postResponses);
+        return PostAllResponse.from(postPage);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -28,6 +28,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final CommentReader commentReader;
     private final UserReader userReader;
+    private final PostReader postReader;
 
     @Transactional
     public PostIdResponse createPost(PostRequest request, Long userId){
@@ -86,7 +87,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostSearchResponse searchPostsByKeyword(String keyword){
 
-        List<PostListResponse> postResponses = postRepository.findAll().stream()
+        List<PostListResponse> postResponses = postReader.searchByTitleOrUserName(keyword).stream()
                 .map(PostListResponse::from)
                 .toList();
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -35,8 +35,10 @@ public class PostService {
 
         for (String tagName : request.postType()) {
             Tag tag = tagReader.findByName(tagName);
-            PostTag.createPostTag(post, tag);
+            PostTag postTag = PostTag.createPostTag(post, tag);
+            post.addPostTag(postTag);
         }
+
 
         return PostIdResponse.from(postRepository.save(post));
     }

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -1,25 +1,19 @@
 package org.sopt.service;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.domain.Comment;
-import org.sopt.domain.Post;
-import org.sopt.domain.User;
-import org.sopt.domain.enums.PostType;
+import org.sopt.domain.*;
 import org.sopt.dto.*;
 import org.sopt.exception.CustomException;
 import org.sopt.repository.PostRepository;
-import org.sopt.repository.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.sopt.common.PostErrorCode.*;
-import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
 import static org.sopt.common.UserErrorCode.USER_UNAUTHORIZED;
 
 @Service
@@ -29,6 +23,7 @@ public class PostService {
     private final CommentReader commentReader;
     private final UserReader userReader;
     private final PostReader postReader;
+    private final TagReader tagReader;
 
     @Transactional
     public PostIdResponse createPost(PostRequest request, Long userId){
@@ -36,7 +31,12 @@ public class PostService {
 
        User user = userReader.getById(userId);
 
-        Post post = new Post(request.title(), request.content(), user, PostType.valueOf(request.postType()));
+       Post post = new Post(request.title(), request.content(), user);
+
+        for (String tagName : request.postType()) {
+            Tag tag = tagReader.findByName(tagName);
+            PostTag.createPostTag(post, tag);
+        }
 
         return PostIdResponse.from(postRepository.save(post));
     }
@@ -95,9 +95,9 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostSearchResponse searchPostsByTag(String tag){
+    public PostSearchResponse searchPostsByTag(String tagName){
 
-        List<PostListResponse> postResponses = postRepository.findAll().stream()
+        List<PostListResponse> postResponses = postReader.searchByTag(tagName).stream()
                 .map(PostListResponse::from)
                 .toList();
 

--- a/src/main/java/org/sopt/service/PostService.java
+++ b/src/main/java/org/sopt/service/PostService.java
@@ -1,5 +1,6 @@
 package org.sopt.service;
 
+import lombok.RequiredArgsConstructor;
 import org.sopt.domain.Comment;
 import org.sopt.domain.Post;
 import org.sopt.domain.User;
@@ -22,23 +23,17 @@ import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
 import static org.sopt.common.UserErrorCode.USER_UNAUTHORIZED;
 
 @Service
+@RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
     private final CommentReader commentReader;
+    private final UserReader userReader;
 
-    public PostService(PostRepository postRepository, UserRepository userRepository, CommentReader commentReader){
-        this.postRepository = postRepository;
-        this.userRepository = userRepository;
-        this.commentReader = commentReader;
-    }
-
-   @Transactional
+    @Transactional
     public PostIdResponse createPost(PostRequest request, Long userId){
        validateTitle(request.title());
 
-       User user = userRepository.findById(userId)
-               .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+       User user = userReader.getById(userId);
 
         Post post = new Post(request.title(), request.content(), user, PostType.valueOf(request.postType()));
 
@@ -84,14 +79,8 @@ public class PostService {
         if (!post.getUser().getId().equals(userId))
             throw new CustomException(USER_UNAUTHORIZED);
 
-        if (request.title() != null) {
-            post.updateTitle(request.title());
-        }
-
-        if (request.content() != null) {
-            post.updateContent(request.content());
-        }
-
+        post.updateTitle(request.title());
+        post.updateContent(request.content());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/service/TagReader.java
+++ b/src/main/java/org/sopt/service/TagReader.java
@@ -1,0 +1,23 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.common.TagErrorCode;
+import org.sopt.domain.Post;
+import org.sopt.domain.Tag;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.TagRepository;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.common.TagErrorCode.TAG_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class TagReader {
+
+    private final TagRepository tagRepository;
+
+    public Tag findByName(String postType){
+        return tagRepository.findByName(postType)
+                .orElseThrow(() -> new CustomException(TAG_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/service/UserReader.java
+++ b/src/main/java/org/sopt/service/UserReader.java
@@ -1,0 +1,21 @@
+package org.sopt.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.domain.User;
+import org.sopt.exception.CustomException;
+import org.sopt.repository.UserRepository;
+import org.springframework.stereotype.Component;
+
+import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class UserReader {
+
+    private final UserRepository userRepository;
+
+    public User getById(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/org/sopt/service/UserReader.java
+++ b/src/main/java/org/sopt/service/UserReader.java
@@ -6,6 +6,7 @@ import org.sopt.exception.CustomException;
 import org.sopt.repository.UserRepository;
 import org.springframework.stereotype.Component;
 
+import static org.sopt.common.AuthErrorCode.USER_NOT_REGISTERED;
 import static org.sopt.common.UserErrorCode.USER_NOT_FOUND;
 
 @Component
@@ -17,5 +18,10 @@ public class UserReader {
     public User getById(Long userId){
         return userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    public User findByIdAndName(Long userId, String name){
+        return userRepository.findByIdAndName(userId, name)
+                .orElseThrow(() -> new CustomException(USER_NOT_REGISTERED));
     }
 }

--- a/src/main/java/org/sopt/utils/JwtUtil.java
+++ b/src/main/java/org/sopt/utils/JwtUtil.java
@@ -1,0 +1,65 @@
+package org.sopt.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.dto.LoginResponse;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil implements InitializingBean {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-expire-period}")
+    @Getter
+    private Integer accessTokenExpirePeriod;
+
+    private Key key;
+
+    public LoginResponse generateToken(final Long id){
+        String accessToken = generateToken(id, accessTokenExpirePeriod);
+
+        return LoginResponse.of(accessToken);
+    }
+
+    private String generateToken(final Long id, final Integer expirePeriod) {
+        Claims claims = Jwts.claims()
+                .add("userId", id)
+                .build();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.JWT_TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + expirePeriod))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    public Claims getTokenBody(final String token){
+        return Jwts.parser()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/org/sopt/utils/JwtUtil.java
+++ b/src/main/java/org/sopt/utils/JwtUtil.java
@@ -25,7 +25,7 @@ public class JwtUtil implements InitializingBean {
 
     @Value("${jwt.access-token-expire-period}")
     @Getter
-    private Integer accessTokenExpirePeriod;
+    private Long accessTokenExpirePeriod;
 
     private Key key;
 
@@ -35,7 +35,7 @@ public class JwtUtil implements InitializingBean {
         return LoginResponse.of(accessToken);
     }
 
-    private String generateToken(final Long id, final Integer expirePeriod) {
+    private String generateToken(final Long id, final Long expirePeriod) {
         Claims claims = Jwts.claims()
                 .add("userId", id)
                 .build();


### PR DESCRIPTION
## 📝 Work Description
### ⭐️ 필수 과제
- [x] 댓글 기능 추가
- [x] 좋아요 기능 추가
- [x] 페이지네이션 적용
### 🥇 선택 과제
- [ ] 외부 API 연동
- [x] 검색 기능 (QueryDSL 기반)
- [x] 태그 기능 확장
- [ ] 대용량 데이터 처리 및 정렬 최적화
- [ ] 병렬 처리 & 비동기화
- [ ] 캐싱으로 성능 최적화
- [ ] 인프라 설계 시각화
- [x] JWT 발급 및 검증 로직 구현
- [x] 로그인 API 리팩터링

### 💡 키워드 과제

- [x] 리버스 프록시란 무엇인가요 ?
- 리버스 프록시는 클라이언트의 요청을 받아 대신 실제 서버로 전달하고, 응답을 다시 클라이언트에게 전달하는 중간 역할을 하는 서버이다. 사용자가 직접 백엔드 서버에 접속하는 것이 아니라, 먼저 리버스 프록시를 거쳐가도록 구성된다. 
그럼 왜 리버스 프록시를 사용할까?
1. 로드 밸런싱
트래픽이 몰릴 경우 하나의 서버만 사용하는 것이 아니라 여러 서버에 요청을 분산시켜 서버의 부담을 줄이고, 서비스가 끊기지 않도록 유지할 수 있다.
3. 보안적인 측면
클라이언트는 실제 서버의 위치를 알 수 없고, 모든 요청은 프록시 서버를 통해 들어오기 때문에 외부 공격으로부터 내부 서버를 보호할 수 있다. 
4. 정적 파일 캐싱 기능
HTML, CSS, 이미지 등 자주 바뀌지 않는 파일은 프록시 서버가 미리 저장해두었다가 빠르게 응답해줄 수 있어 전체 서비스 속도가 빨라진다.
=> Nginx, Apache, Cloudflare, AWS Load Balancer 등 다양한 도구들이 리버스 프록시 역할을 한다.
- [x] 쿠키 vs 웹 스토리지 간단히
- 쿠키와 웹 스토리지는 모두 브라우저에 데이터를 저장할때 쓰임 but 용도와 동작 방식에 차이가 있다.
쿠키는 주로 서버와 통신할 때 필요한 정보를 저장하는 데 사용된다. 브라우저가 서버에 요청을 보낼 때마다 쿠키에 저장된 데이터도 함께 전송되기 때문에, 로그인 상태 유지나 사용자 인증에 자주 사용된다. 다만 저장 용량이 작고, 서버로 매번 전송되기 때문에 속도와 보안 측면에서 주의가 필요하다.
웹 스토리지는 클라이언트에서 데이터를 저장하는 공간으로, 서버와는 자동으로 데이터를 주고받지 않는다. localStorage는 데이터를 브라우저에 영구적으로 저장하고, sessionStorage는 브라우저 탭을 닫을 때까지만 유지된다. 용량도 크고, 속도도 빠르기 때문에 프론트엔드에서 임시 데이터나 사용자 설정 값을 저장하는 데 자주 쓰인다.
- [x] `OAuth` 란 무엇이고 어떤 이유에 의해 필요하게 되었을까요 ?
- OAuth는 외부 서비스에 내 계정 권한의 일부를 안전하게 위임할 수 있게 해주는 인증 방식이다.
과거에는, 어떤 서비스를 이용하려면 직접 내 계정의 아이디와 비밀번호를 입력해야 했는데.. 보안상 위험하기 때문에 
OAuth를 사용해서 비밀번호 없이, 외부 서비스가 일정한 권한만을 가지고 내 계정 정보를 사용할 수 있게 해주는 것이다. 사용자가 외부 앱에 로그인 요청을 하면, 실제 인증은 구글/카카오에게 맡기고, 사용자가 동의하면 access token을 발급해 외부 앱이 그 토큰으로 제한된 정보를 조회할 수 있게 해준다.

## 🔥 Trouble Shooting
- 문제 상황 & 해결 방법 간단 정리  
1. @NotBlank
Long타입에 @NotBlank를 써서 400에러가 계속 떴는데 @NotBlank는 string 타입에만 적용되고 다른 타입에는 @NotNull 또는 @NotEmpty를 써야한다. @NotNull과 @NotEmpty의 차이는 @NotEmpty가 null 뿐만 아니라 비어있는 경우도 허용하지 않는다는 것이다.("" 허용 안함)
따라서,,,
Long에 쓴다면 → @NotNull
List에 쓴다면 → @NotEmpty
String에 쓴다면 → @NotBlank

2. 토큰 앞뒤에 불필요한 공백 포함 -> trim()을 통해 공백 제거
3. spring bean validation을 써서 message를 넣어줬음에도 응답 message에는 해당 validation message가 안들어갔었음
NotBlank, @NotEmpty 등 Spring Bean Validation에서 message를 지정해도, GlobalExceptionHandler에서 메시지를 꺼내지 않으면 응답에 포함되지 않는다는 점을 몰랐어서 메시지를 응답에 포함하도록 수정

## 🤔 고민해본 점
- Tag 최대 두개까지 선택 가능 -> Tag 테이블, PostTag 테이블 추가
기존에 한개만 선택 가능했던 태그였어서 post 엔티티가 tag도 함께 가지도록 했었는데 최대 두개 선택으로 바뀌면서 엔티티가 수정 필요,..
이때 고민했던 부분은 Post 엔티티 안에 tag1, tag2처럼 두 개의 필드를 따로 둘지, 아니면 Tag 테이블을 따로 만들고 PostTag라는 중간 테이블을 두어 다대다(N:M) 관계로 연결할지를 결정하는 부분이었습니다!
저는 후자를 선택했는데 이유는

1. 태그로 게시글을 검색하거나 필터링하는 쿼리를 작성할 때 성능이 더 좋다고 생각했습니다.
예를 들어, "서버" 태그가 포함된 게시글을 조회하는 경우에도 JOIN만으로 효율적인 검색이 가능
2.확장성과 유연성 측면에서 유리.
현재는 최대 두 개지만, 이후 요구사항이 변경되어 무제한으로 늘어나더라도 테이블 구조를 바꿀 필요가 없다고 생각했습니다.
3. 정규화에 따라 데이터 중복을 방지할 수 있고, 각 태그를 독립적으로 관리하기 편리
동일한 태그가 여러 게시글에서 중복되더라도 하나의 Tag 레코드를 참조함으로써 데이터 일관성을 유지할 수 있다고 생각했습니다.

- 좋아요 누르기/취소하기 -> save/delete 방식 선택
좋아요 기능을 구현할 때 여러 가지 방법이 존재했는데, 저는 좋아요를 누르면 Like 객체가 생성되고, 취소하면 삭제되는 방식(save/delete) 으로 구현했습니다.
처음에는 boolean 상태값으로 구현할까도 고민했지만, 이 경우 좋아요를 누른 뒤 취소한 레코드도 계속해서 DB에 남게 되어 데이터가 불필요하게 많이 쌓일 수 있다는 점이 걱정되었습니다. 실제로는 유저가 한 번만 좋아요를 눌렀다가 취소하는 경우도 많기 때문에, 삭제하는 것이 더 깔끔하다고 판단했습니다.
다만 이 방식은 좋아요 누르기와 취소 시마다 insert/delete 쿼리가 발생하기 때문에, boolean 필드를 update하는 방식보다 성능적으로 불리할 수 있다는 우려도 있었습니다. 특히 좋아요/취소가 반복되는 경우엔 write I/O가 더 많아질 수 있습니다.
하지만 현재 서비스 규모에서는 이 방법이 낫다고 생각했고, 좋아요 수를 구할 때도 count 쿼리로 쉽게 처리할 수 있어 실용적이라고 느꼈습니다.
서비스가 커지게 되면 어떤 방식을 많이 사용하고 다른 분들은 어떤 방식을 쓰셨는지 궁금합니다!

- @AuthenticationPrincipal 사용
userId를 HTTP 헤더에 직접 넣지 않고 JWT 필터에서 Authentication 객체를 만들고 그 안에 userId를 principal로 설정해서 이후 Spring MVC가 @AuthenticationPrincipal로 등록된 파라미터를 Authentication.getPrincipal()에서 꺼내서 주입하도록 했습니다.
이렇게 할 경우,,
HTTP 요청은 Stateless하기 때문에, 매 요청마다 JWT를 통해 인증 여부를 확인해야하는데 이 과정을 필터에서 수행하고, SecurityContext에 한 번 등록하면,그 뒤에는 Spring이 알아서 @AuthenticationPrincipal에 주입해주기 때문에 컨트롤러에서 인증에 신경을 쓸 필요가 없기 때문에 @AuthenticationPrincipal 를 사용했습니다!

## 📢 To Reviewers

다들 바쁘신데 시간 내 리뷰해주셔서 감사합니다🙇‍♀️

## 📷 Screenshot
<img width="936" alt="스크린샷 2025-06-25 오후 6 07 49" src="https://github.com/user-attachments/assets/35366252-e6f1-4a61-bfe3-5f6b9fdf9345" />
<img width="943" alt="스크린샷 2025-06-25 오후 6 08 12" src="https://github.com/user-attachments/assets/d1a545eb-eb64-489b-94f9-0c0540d188db" />
<img width="945" alt="스크린샷 2025-06-27 오후 3 19 04" src="https://github.com/user-attachments/assets/6cd2b6b0-7b40-4ea3-a481-5a3c594a9459" />
<img width="954" alt="스크린샷 2025-06-27 오후 3 20 08" src="https://github.com/user-attachments/assets/dac87d71-7667-4db3-b4e1-08c86c71529e" />
<img width="948" alt="스크린샷 2025-06-27 오후 3 20 33" src="https://github.com/user-attachments/assets/e4c28e1a-5cfd-45b5-bd99-d12755f4042f" />